### PR TITLE
Update deployment workflow for Azure Web App

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,12 @@
-name: Deploy Flask + React to Linux Server
+name: Deploy Flask + React to Azure Web App
 
 on:
   push:
     branches:
       - master
+
+env:
+  AZURE_WEBAPP_NAME: skraafoto-devdisplay
 
 jobs:
   build-and-deploy:
@@ -75,21 +78,18 @@ jobs:
           echo "📁 Final deploy folder contents:"
           ls -alh deploy/
 
-      - name: Deploy via SCP
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: 172.105.95.18
-          username: root
-          key: ${{ secrets.DEPLOY_KEY }}
-          source: "deploy/*"
-          target: "/var/www/skraafoto"
-          strip_components: 1
+      - name: Archive deployment package
+        run: |
+          cd deploy
+          zip -r ../deploy.zip .
 
-      - name: Restart Apache
-        uses: appleboy/ssh-action@master
+      - name: Login to Azure
+        uses: azure/login@v2
         with:
-          host: 172.105.95.18
-          username: root
-          key: ${{ secrets.DEPLOY_KEY }}
-          script: |
-            sudo systemctl restart apache2
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Deploy to Azure Web App
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          package: deploy.zip


### PR DESCRIPTION
## Summary
- replace legacy Linux SCP deployment with Azure Web App deployment steps
- archive build output and backend files into a package for publishing
- authenticate with Azure using provided credentials and deploy the package

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942bcc2152083278035dd1c1ad3fd42)

## Summary by Sourcery

Update the deployment workflow to publish the built Flask + React application to an Azure Web App instead of a self-managed Linux server.

Deployment:
- Replace SCP/SSH-based deployment to a Linux server with Azure Web App deployment using GitHub Actions.
- Package the build output into a ZIP artifact and deploy it to the configured Azure Web App using Azure credentials.